### PR TITLE
[skip ci] fix(ci): Upload zip with manifest on GH releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
         tag_name: v${{ inputs.version }}
         name: Release v${{ inputs.version }}
         body: ${{ steps.git-cliff.outputs.content }}
-        # We upload ONLY the clean zip we made in Step 1
-        files: ./Waves_v${{ inputs.version }}.zip
+        # Upload zip with correct manifest from step 2
+        files: ./publish/*.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
self explained

Reason why we upload zip with manifest in the GH release is that, there is no reason not to. User might be coming from the repo and want to download a working copy of the plugin to be flung directly to Collapse, this fixes "manifest not found" error Collapse will throw out.